### PR TITLE
ci: only run deploy on `master` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
   # --------------DEPLOY TO PAGES--------------
   deploy:
     needs: [lint, unit-test, dist]
+    if: github.ref == 'refs/heads/master'
 
     environment:
       name: github-pages


### PR DESCRIPTION
Only run deploy on `master` branch