### PR TITLE
feat(tokens)!: rename `Tabs Item` text color tokens

### DIFF
--- a/tokens/src/tokens/component/navigation/Tabs/tabs__item.json
+++ b/tokens/src/tokens/component/navigation/Tabs/tabs__item.json
@@ -9,10 +9,10 @@
             }
           },
           "text": {
-            "base": {
+            "enabled": {
               "value": "{alias.color.text.body.weak.value}"
             },
-            "active": {
+            "selected": {
               "value": "{alias.color.text.action.quiet.activated.value}"
             },
             "disabled": {


### PR DESCRIPTION
BREAKING CHANGE: The following tokens have been renamed:
- `cmp.tabs.item.color.text.active` -> `[...].text.selected`
- `cmp.tabs.item.color.text.base` -> `[...].text.enabled`